### PR TITLE
ci: migrate soldeer publishing to rainix-autopublish

### DIFF
--- a/.github/workflows/package-release.yaml
+++ b/.github/workflows/package-release.yaml
@@ -1,0 +1,11 @@
+name: Package Release
+on:
+  push:
+    branches:
+      - main
+jobs:
+  release:
+    uses: rainlanguage/rainix/.github/workflows/rainix-autopublish.yaml@main
+    with:
+      soldeer-package: rain-string
+    secrets: inherit

--- a/.github/workflows/publish-soldeer.yaml
+++ b/.github/workflows/publish-soldeer.yaml
@@ -1,9 +1,0 @@
-name: Publish to Soldeer
-on:
-  push:
-    tags:
-      - "v*"
-jobs:
-  publish:
-    uses: rainlanguage/rainix/.github/workflows/publish-soldeer.yaml@main
-    secrets: inherit

--- a/foundry.toml
+++ b/foundry.toml
@@ -1,3 +1,7 @@
+[package]
+name = "rain-string"
+version = "0.2.0"
+
 [profile.default]
 libs = ["dependencies"]
 # See more config options https://github.com/foundry-rs/foundry/tree/master/config


### PR DESCRIPTION
Part of removing the manual `publish-soldeer` reusable from rainix.

- Add `[package]` (name=`rain-string`, version=`0.2.0` = current soldeer registry release) to `foundry.toml` — autopublish reads the version from here.
- Replace tag-driven `publish-soldeer` wrapper with `package-release.yaml` calling `rainix-autopublish` (`soldeer-package: rain-string`), which publishes on push to main when the version diverges from the registry.
- Release model changes from `git tag vX.Y.Z` → bump `[package].version` + merge to main.

No publish fires from this PR (version equals the current registry release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Package version updated to 0.2.0
  * Refined release automation workflow: transitioned from tag-triggered publishing to automatic releases on main branch updates
  * Updated package metadata configuration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->